### PR TITLE
bugfix hub, changed drawcustom to entity_id 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ This Service call draws a image local in home assistant, and will send it to the
 Example Call:
 ```
 service: open_epaper_link.drawcustom
+target:
+  entity_id:
+    - open_epaper_link.0000021EC9EC743A
 data:
-  mac: 0000028DF056743A
-  width: 640
-  height: 384
   background: white
   rotate: 270
   payload:

--- a/custom_components/open_epaper_link/__init__.py
+++ b/custom_components/open_epaper_link/__init__.py
@@ -5,22 +5,27 @@ from homeassistant.core import HomeAssistant
 from . import hub
 from .const import DOMAIN
 import logging
+import pprint
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def setup(hass, config):
     # callback for the image downlaod service
-    async def drawcustomservice(call) -> None:
-        mac = call.data.get("mac", "000000000000")
-        payload = call.data.get("payload", "")
-        width = call.data.get("width", "")
-        height = call.data.get("height", "")
-        rotate = call.data.get("rotate", "0")
-        background = call.data.get("background","white")
-        ip = hass.states.get(DOMAIN + ".ip").state
-        imgbuff = customimage(payload,width,height,background,mac,rotate)
-        result = await hass.async_add_executor_job(uploadimg, imgbuff, mac, ip)
+    async def drawcustomservice(service: ServiceCall) -> None:
+        # mac = call.data.get("mac", "000000000000")
+        # payload = call.data.get("payload", "")
+        # width = call.data.get("width", "")
+        # height = call.data.get("height", "")
+        # rotate = call.data.get("rotate", "0")
+        # background = call.data.get("background","white")
+        ip = hass.states.get(DOMAIN + ".ip").state 
+        entity_ids = service.data.get("entity_id")
+        for entity_id in entity_ids:
+            _LOGGER.info("Called entity_id: %s" % (entity_id))
+            imgbuff = customimage(entity_id, service, hass)
+            id = entity_id.split(".")
+            result = await hass.async_add_executor_job(uploadimg, imgbuff, id[1], ip)
 
     # callback for the image downlaod service
     async def dlimg(call) -> None:

--- a/custom_components/open_epaper_link/hub.py
+++ b/custom_components/open_epaper_link/hub.py
@@ -92,15 +92,34 @@ class Hub:
             ch = tag.get('ch')
             ver = tag.get('ver')
             #required for automations
-            self._hass.states.set(DOMAIN + "." + tagmac + "hwtype", hwType,{"icon": "mdi:fullscreen","friendly_name": "Hardware Type","should_poll": False})
-            hwmap = {0: "1.54″ BWR",1: "2.9″ BWR",2: "4.2″ BWR",5: "7.4″ BWR", 17: "2.9″ BWR NFC",17: "2.9″ BWR NFC",240: "Segmented UK"}
+           
+            hwmap = {
+                0: ["1.54″ BWR",152,152],
+                1: ["2.9″ BWR",296, 128],
+                2: ["4.2″ BWR",400, 300],
+                3: ["2.9″ BWR",168, 384],
+                4: ["7.4″ BWR",800, 480],
+                5: ["7.4″ BWR",640, 384],
+                6: ["2.13″ BWR",212,104],
+                7: ["3.5″ BWR",184, 384],
+            }
+
+            self._hass.states.set(DOMAIN + "." + tagmac, hwType,{
+                "icon": "mdi:fullscreen",
+                "friendly_name": tagmac,
+                "should_poll": False,
+                "hwtype": hwType,
+                "hwstring": hwmap[hwType][0],
+                "width": hwmap[hwType][1],
+                "height": hwmap[hwType][2],
+                })
             self.data[tagmac] = dict()
             self.data[tagmac]["temperature"] = temperature
             self.data[tagmac]["rssi"] = RSSI
             self.data[tagmac]["battery"] = batteryMv
             self.data[tagmac]["lqi"] = LQI
             self.data[tagmac]["hwtype"] = hwType
-            self.data[tagmac]["hwstring"] = hwmap[hwType]
+            self.data[tagmac]["hwstring"] = hwmap[hwType][0]
             self.data[tagmac]["contentmode"] = contentMode
             self.data[tagmac]["lastseen"] = lastseen
             self.data[tagmac]["nextupdate"] = nextupdate

--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -70,8 +70,13 @@ def getres(hwtype):
 
 
 # custom image generator
-def customimage(payload,width,height,background,mac,rotate):
-
+def customimage(entity_id, service, hass):
+        
+    payload = service.data.get("payload", "")
+    rotate = service.data.get("rotate", "0")
+    background = service.data.get("background","white")
+    width = hass.states.get(entity_id).attributes['width']
+    height = hass.states.get(entity_id).attributes['height']
     if rotate == 0:
         img = Image.new('RGB', (width, height), color=background)
     elif rotate == 90:
@@ -155,8 +160,7 @@ def customimage(payload,width,height,background,mac,rotate):
         if element["type"] == "icon":
             # ttf from https://github.com/Templarian/MaterialDesign-Webfont/blob/master/fonts/materialdesignicons-webfont.ttf
             font_file = os.path.join(os.path.dirname(__file__), 'materialdesignicons-webfont.ttf')
-
-            meta_file = os.path.join(os.path.dirname(__file__), "materialdesignicons-webfont_meta.json")  # Replace with the actual path to your JSON file
+            meta_file = os.path.join(os.path.dirname(__file__), "materialdesignicons-webfont_meta.json") 
             f = open(meta_file) 
             data = json.load(f)
             chr_hex = ""
@@ -168,11 +172,13 @@ def customimage(payload,width,height,background,mac,rotate):
             font = ImageFont.truetype(font_file, element['size'])
             d.text((element['x'],  element['y']), chr(int(chr_hex, 16)), fill=element['color'], font=font)
 
-    img = img.rotate(rotate, expand=True)
+
+    if "rotate" in element: 
+        img = img.rotate(rotate, expand=True)
 
     buf = io.BytesIO()
     img.save(buf, format='JPEG', quality=95)
-    img.save(os.path.join(os.path.dirname(__file__), mac + '.jpg'))
+    img.save(os.path.join(os.path.dirname(__file__), entity_id + '.jpg'))
     byte_im = buf.getvalue()
     return byte_im
 

--- a/custom_components/open_epaper_link/sensor.py
+++ b/custom_components/open_epaper_link/sensor.py
@@ -59,6 +59,7 @@ class IPSensor(SensorEntity):
             "model": "esp32",
             "manufacturer": "OpenEpaperLink",
         }
+
     def update(self) -> None:
         self._attr_native_value = self._hub.data["ap"]["ip"]
 
@@ -458,6 +459,7 @@ class HWTypeSensor(SensorEntity):
     def device_info(self) -> DeviceInfo:
         return {
             "identifiers": {(DOMAIN, self._eslid)},
+            "name": self.name,
         }
     def update(self) -> None:
         eslid = self._eslid

--- a/custom_components/open_epaper_link/services.yaml
+++ b/custom_components/open_epaper_link/services.yaml
@@ -21,22 +21,10 @@ dlimg:
 drawcustom:
   name: Draw Custom Image
   description: Draws a custom image
+  target:
+    entity:
+      domain: open_epaper_link
   fields:
-    mac:
-      name: Mac
-      description: Mac of the ESL to display the information on  THE MAC HAS TO BE IN QUOTATION MARKS
-      required: true
-      example: '"0000021DBB093411"'
-    width:
-      name: width of image
-      description: With of image
-      required: true
-      example: 400
-    height:
-      name: height
-      description: height of image
-      required: true
-      example: 300
     payload:
       name: Payload
       description: payload to draw

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -2,6 +2,9 @@ With drawcustom you can create a image in HomeAssistant and send the rendered im
 The basic service call, looks like this:
 ```
 service: open_epaper_link.drawcustom
+target:
+  entity_id:
+    - open_epaper_link.0000028DF056743B
 data:
   mac: 0000028DF056743A
   width: 640

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -6,7 +6,6 @@ target:
   entity_id:
     - open_epaper_link.0000028DF056743B
 data:
-  mac: 0000028DF056743A
   width: 640
   height: 384
   background: white


### PR DESCRIPTION
**This is a breaking commit!**

- Changed usage of drawcustom to use of entitiy_id, so no need to configure width, height and mac anymore.
- Changed format of hwmap in hub.py to support width and height per hwtype. 
- Changed state update to write hwtype, width, height into entity attribute.


