### PR TITLE
Fix TypeError when temperature isn't present

### DIFF
--- a/custom_components/open_epaper_link/sensor.py
+++ b/custom_components/open_epaper_link/sensor.py
@@ -121,7 +121,9 @@ class APTempSensor(SensorEntity):
             "identifiers": {(DOMAIN, "ap")}
         }
     def update(self) -> None:
-        self._attr_native_value = round(self._hub.data["ap"]["temp"],1)
+        temp = self._hub.data["ap"]["temp"]
+        if temp:
+            self._attr_native_value = round(temp,1)
         
 class APWifiStatusSensor(SensorEntity):
     def __init__(self, hub):


### PR DESCRIPTION
Fixes an error I was seeing in the homeassistant logs, due to my openepaper AP not reporting temperature:

```
2023-10-14 03:58:00.733 ERROR (MainThread) [homeassistant.helpers.entity] Update for sensor.ap_temp fails
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.10/site-packages/homeassistant/helpers/entity.py", line 554, in async_update_ha_state
    await self.async_device_update()
  File "/srv/homeassistant/lib/python3.10/site-packages/homeassistant/helpers/entity.py", line 781, in async_device_update
    await hass.async_add_executor_job(self.update)
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/root/.homeassistant/custom_components/open_epaper_link/sensor.py", line 124, in update
    self._attr_native_value = round(self._hub.data["ap"]["temp"],1)
TypeError: type NoneType doesn't define __round__ method
```

HomeAssistant then reports the sensor as "Unknown" rather than crashing:
<img width="294" alt="image" src="https://github.com/jonasniesner/open_epaper_link_homeassistant/assets/192620/55f12791-49a1-4b31-b099-00b96cdd26a4">
