### PR TITLE
Add "dry-run" to "draw custom"

### DIFF
--- a/custom_components/open_epaper_link/__init__.py
+++ b/custom_components/open_epaper_link/__init__.py
@@ -11,16 +11,21 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def setup(hass, config):
-    # callback for the image downlaod service
+    # callback for the draw custom service
     async def drawcustomservice(service: ServiceCall) -> None:
         ip = hass.states.get(DOMAIN + ".ip").state 
         entity_ids = service.data.get("entity_id")
+        dry_run = service.data.get("dry-run", False)
         for entity_id in entity_ids:
             _LOGGER.info("Called entity_id: %s" % (entity_id))
             imgbuff = customimage(entity_id, service, hass)
             id = entity_id.split(".")
-            result = await hass.async_add_executor_job(uploadimg, imgbuff, id[1], ip)
-
+            if (dry_run is False):
+                result = await hass.async_add_executor_job(uploadimg, imgbuff, id[1], ip)
+            else:
+                _LOGGER.info("Running dry-run - no upload to AP!")
+                result = True
+                
     # callback for the image downlaod service
     async def dlimg(service: ServiceCall) -> None:
         ip = hass.states.get(DOMAIN + ".ip").state 

--- a/custom_components/open_epaper_link/services.yaml
+++ b/custom_components/open_epaper_link/services.yaml
@@ -67,6 +67,11 @@ drawcustom:
       description: 0, 90, 180, 270
       required: false
       example: 90
+    dry-run:
+      name: Dry-run
+      description: Generate image, but don't send it to the AP.
+      required: false
+      example: true
 
 lines5:
   name: 5 Line Display


### PR DESCRIPTION
When using "drawcustom", it often requires quite a few tries and adjustment to get it "right".
Currently, all changes are pushed to the tag, but it usually is sufficent to look at the jpg created in HASS to check if the "design" look good. No need to "stress" the AP or use battery on every single test. 

With this change, it's possible to add a "dry-run: true" and it will create the jpg, but not upload it to the AP/tag.