### PR TITLE
Add anchor parameter to icon

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -188,7 +188,8 @@ def customimage(entity_id, service, hass):
             if chr_hex == "":
                 raise HomeAssistantError("Non valid icon used")
             font = ImageFont.truetype(font_file, element['size'])
-            d.text((element['x'],  element['y']), chr(int(chr_hex, 16)), fill=getIndexColor(element['color']), font=font)
+            anchor = element['anchor'] if 'anchor' in element else "la"
+            d.text((element['x'],  element['y']), chr(int(chr_hex, 16)), fill=getIndexColor(element['color']), font=font, anchor=anchor)
        #dlimg
         if element["type"] == "dlimg":
             url = element['url']

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -41,7 +41,7 @@ data:
 - color (optional) frontcolor of text. default: black
 - y (optional) position on y axis
 - y_padding (optional) offset to last text or multiline y position. works only if y is not provided. default: 10
-- anchor (optional) Position from the text, which shall be used as anchor. defualt: lf = left_top (mm = middle_middle) see https://pillow.readthedocs.io/en/stable/handbook/text-anchors.html
+- anchor (optional) Position from the text, which shall be used as anchor. default: lt = left_top (mm = middle_middle) see https://pillow.readthedocs.io/en/stable/handbook/text-anchors.html
 
 ### multiline
 this payload takes a string and a delimiter, and will break the string on every delimiter and move the cursor the amount if offset_y down the canvas.
@@ -68,7 +68,7 @@ this payload takes a string and a delimiter, and will break the string on every 
 - start_y (optional) position on y axis
 - align (optional) left,center,right default: left (if text contains \n this set the alignment of the lines)
 - spacing (optional) if multiline text, spacing between single lines
-- max_width (optional) creats line breaks in the provided text, if text is longer than max_width defines (this will disable the anchor attribute)
+- max_width (optional) creats line breaks in the provided text, if text is longer than max_width defines
 - y_padding (required) offset to last text or multiline y position. works only if start_y is not provided. e.g.: 10
 
 ### line
@@ -125,6 +125,7 @@ Draws a line
 - value (required) name of icon. from: https://pictogrammers.com/library/mdi/
 - size (required) e.g. 20
 - color (required)  e.g. black, white, red
+- anchor (optional) Position from the text, which shall be used as anchor. default: la = left/ascender see https://pillow.readthedocs.io/en/stable/handbook/text-anchors.
 
 ### dlimg
 ```


### PR DESCRIPTION
Add anchor parameter that defaults to 'la' which is the PIL default. Keeping the default as 'la' makes this change backwards compatible with existing configurations without anchor.

Adding this feature allows icon layouts that follow similar placement as text elements.