### PR TITLE
Support icon names with "mdi:" prefix

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -181,8 +181,13 @@ def customimage(entity_id, service, hass):
             f = open(meta_file) 
             data = json.load(f)
             chr_hex = ""
+
+            value = element['value']
+            if value.startswith("mdi:"):
+                value = value[4:]
+
             for icon in data:
-                if icon['name'] == element['value']:
+                if icon['name'] == value:
                     chr_hex = icon['codepoint']
                     break
             if chr_hex == "":

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -179,7 +179,8 @@ Draws an icon.
 ```
 
 #### Parameters:
-- value (required) name of icon from https://pictogrammers.com/library/mdi/
+
+- value (required) name of icon from <https://pictogrammers.com/library/mdi/>, may be optionally prefixed with "mdi:"
 - size (required) e.g. 20
 - color (required) e.g. black, white, red
 - anchor (optional) position from the text, (see [text](#text) above for details)


### PR DESCRIPTION
Optionally allow icon names to be prefixed with "mdi:". This allows you to reuse the same icon names as home assistant. Especially helpful when reusing an icon from an entity in home assistant to display on a tag.