### PR TITLE
allow icon aliases

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -187,7 +187,7 @@ def customimage(entity_id, service, hass):
                 value = value[4:]
 
             for icon in data:
-                if icon['name'] == value:
+                if icon['name'] == value or value in icon['aliases']:
                     chr_hex = icon['codepoint']
                     break
             if chr_hex == "":


### PR DESCRIPTION
Also search in the icon aliases for the supplied icon name.

I'm using the state of a weather entity to determine an icon. However, the weather entity state often doesn't 100% correlate to the icon name, but to one of its aliases. For example the state will be `partlycloudy`, while the icon's name is `(weather-)partly-cloudy`, one of the aliases is `(weather-)partlycloudy` though.

So with allowing the icon's aliases I won't have to manually convert names, but I can just use `weather-{{ states('weather.some_entity') }}` (hopefully, I haven't checked all weather states & corresponding icons). 