### PR TITLE
Enable use of `null` to not draw rectangle inside

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Every tag and the AP is exposed as a device.
 ### Services
 
 #### drawcustom
-This Service call draws a image local in home assistant, and will send it to the EPaper AP afterwards. Note that the rectangle is not transparent, so if it is drawn after other objects, it may overwrite them.
+This Service call draws a image local in home assistant, and will send it to the EPaper AP afterwards. To not draw the inside of the rectangle use `null` as the `fill` color value.
 
 Example Call:
 ```

--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -52,6 +52,9 @@ def get_wrapped_text(text: str, font: ImageFont.ImageFont,
 
 # converts a color name to the corresponding color index for the palette
 def getIndexColor(color):
+    if color is None:
+        return None
+
     color_str = str(color)
     if color_str == "black" or color_str == "b":
         return black

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -161,7 +161,7 @@ Draws a rectangle.
 - **y_start** (required)
 - **x_end** (required)
 - **y_end** (required)
-- **fill** (required) e.g. black
+- **fill** (required) e.g. black, use `null` to not draw the inside
 - **outline** (required) e.g. red
 - **width** (required) width of outline, e.g. 2
 


### PR DESCRIPTION
Currently the documentation warns that the rectangle may cover previous information. However, using `None` as the color allows not drawing anything. Allowing a `null` yaml value for colors solves this.