### PR TITLE
add missing `math` import

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -3,6 +3,7 @@ import io
 import logging
 import os
 import pprint
+import math
 import json
 import requests
 import qrcode


### PR DESCRIPTION
There is a usage of `math.floor` in the `plot` draw option but the `math` module was not imported before.