### PR TITLE
Fix from recent PR 80 to allow MDI Alias icon names (after name is checked first)

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -202,9 +202,14 @@ def customimage(entity_id, service, hass):
                 value = value[4:]
 
             for icon in data:
-                if icon['name'] == value or value in icon['aliases']:
+                if icon['name'] == value:
                     chr_hex = icon['codepoint']
                     break
+            if chr_hex == "":
+                for icon in data:
+                    if value in icon['aliases']:
+                        chr_hex = icon['codepoint']
+                        break
             if chr_hex == "":
                 raise HomeAssistantError("Non valid icon used")
             font = ImageFont.truetype(font_file, element['size'])


### PR DESCRIPTION
This update now checks for icon name, if that fails, THEN it checks through the aliases of icons. 

Looks like the icon list is checked A-Z, so some icons which have aliases higher than the actual name (e.g. water, alias = liquid-spot) gets picked before the actual name (icon liquid-spot has an alias of water) has chance to be picked.