### PR TITLE
Match drawcustom multiline params with text

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -176,14 +176,17 @@ def customimage(entity_id, service, hass):
         if element["type"] == "multiline":
             d = ImageDraw.Draw(img)
             d.fontmode = "1"
-            font_file = os.path.join(os.path.dirname(__file__), element['font'])
-            font = ImageFont.truetype(font_file, element['size'])
+            size = element.get('size', 20)
+            font = element.get('font', "ppb.ttf")
+            font_file = os.path.join(os.path.dirname(__file__), font)
+            font = ImageFont.truetype(font_file, size)
+            color = element.get('color', "black")
             _LOGGER.debug("Got Multiline string: %s with delimiter: %s" % (element['value'],element["delimiter"]))
             lst = element['value'].replace("\n","").split(element["delimiter"])
-            pos = element.get('start_y', pos_y + element['y_padding'])
+            pos = element.get('start_y', pos_y + element.get('y_padding', 10))
             for elem in lst:
                 _LOGGER.debug("String: %s" % (elem))
-                d.text((element['x'], pos ), str(elem), fill=getIndexColor(element['color']), font=font)
+                d.text((element['x'], pos ), str(elem), fill=getIndexColor(color), font=font)
                 pos = pos + element['offset_y']
             pos_y = pos
         #icon

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -108,12 +108,12 @@ This payload takes a string and a delimiter, and will break the string on every 
 - **value** (required) the text to display
 - **delimiter** (required) the delimiting character, to split value, e.g. `#`
 - **x** (required) position on x axis
-- **size** (required) size of text, e.g. 20
-- **font** (required) name of ttf font file (see [text](#text) above for details)
-- **color** (optional) font color of text. default: black
-- **y_padding** (required) offset to last text or multiline y position. works only if `start_y` is not provided. e.g.: `10`
 - **offset_y** (required) This is the line height: how much space to start the next line down the y axis.
 - **start_y** (optional) position on y axis
+- **y_padding** (optional) offset to last text or multiline y position. works only if `start_y` is not provided. default: 10
+- **size** (optional) size of text, default: 20
+- **font** (optional) name of ttf font file (see [text](#text) above for details). default: `ppb.ttf`
+- **color** (optional) font color of text. default: black
 - **align** (optional) left, center, right default: left (if text contains `\n` this sets the alignment of the lines)
 - **spacing** (optional) if multiline text, spacing between single lines
 - **visible** (optional) show element, default: True
@@ -124,7 +124,7 @@ Draws a line.
 
 ```yaml
 - type: line
-  x_start: 20 
+  x_start: 20
   x_end: 380
   y_start: 15
   y_end: 15
@@ -149,7 +149,7 @@ Draws a rectangle.
 
 ```yaml
 - type: rectangle
-  x_start: 20 
+  x_start: 20
   x_end: 80
   y_start: 15
   y_end: 30
@@ -208,10 +208,10 @@ Downloads an image from a URL and renders it.
 
 - **url** (required) url of the image to download
 - **x** (required) e.g. 20
-- **y** (required)  e.g. 10
-- **xsize** (required)  e.g. x size the image is resized
-- **ysize** (required)  e.g. y size the image is resized
-- **rotate** (required)  e.g. 0
+- **y** (required) e.g. 10
+- **xsize** (required) e.g. x size the image is resized
+- **ysize** (required) e.g. y size the image is resized
+- **rotate** (required) e.g. 0
 - **visible** (optional) show element, default: True
 
 ### qrcode
@@ -231,7 +231,7 @@ Downloads an image from a URL and renders it.
 
 - **data** (required) content of the qr code
 - **x** (required) e.g. 20
-- **y** (required)  e.g. 10
+- **y** (required) e.g. 10
 - **boxsize** (required) e.g. 2
 - **border** (required) e.g. 2
 - **color** (required) e.g. black
@@ -266,6 +266,7 @@ The plot will scale according to the data, so you should only use multiple entit
 ```
 
 #### Parameters:
+
 - **x_start** (optional, default `0`) the left start of the whole plot (inlusive)
 - **y_start** (optional, default `0`) the top start of the whole plot (inlusive)
 - **x_end** (optional, default `0`) the right end of the whole plot (inlusive)


### PR DESCRIPTION
# What?
Set as optional the params of `multiline` that are optional in `text`.

Also, minor markdown fixes (Autoformat).

# Why?
To simplify switching between text and multiline, and make multiline easier to use.