### PR TITLE
Added icon name to error message if doesn't exist in MDI.

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -205,7 +205,7 @@ def customimage(entity_id, service, hass):
                         chr_hex = icon['codepoint']
                         break
             if chr_hex == "":
-                raise HomeAssistantError("Non valid icon used")
+                raise HomeAssistantError("Non valid icon used: "+ value)
             font = ImageFont.truetype(font_file, element['size'])
             anchor = element['anchor'] if 'anchor' in element else "la"
             d.text((element['x'],  element['y']), chr(int(chr_hex, 16)), fill=getIndexColor(element['color']), font=font, anchor=anchor)


### PR DESCRIPTION
Handy for when you are creating a tag with LOTS of icons and one or more do not exists - the error message now tells you which. Not that I misspelled one at all....!