### PR TITLE
Updated documentation for locally stored image for dlimg

### DIFF
--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -206,7 +206,7 @@ Downloads an image from a URL and renders it.
 
 #### Parameters:
 
-- **url** (required) url of the image to download
+- **url** (required) url of the image to download. Either the full http/https URL address for an externally accessible image, or locally stored image needs to be e.g. `url: /config/media/chuck-icon.jpg` if stored within a folder called `media` in your main config or homeassistant folder.
 - **x** (required) e.g. 20
 - **y** (required) e.g. 10
 - **xsize** (required) e.g. x size the image is resized


### PR DESCRIPTION
Added document note for accessing locally sored images for the dlimg function - their "url" needs to be the correct path to them from the base config folder.