### PR TITLE
Fix font antialiasing in plot labels

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -299,6 +299,7 @@ def customimage(entity_id, service, hass):
         # plot
         if element["type"] == "plot":
             img_draw = ImageDraw.Draw(img)
+            img_draw.fontmode = "1"
             # Obtain drawing region, assume whole canvas if nothing is given
             x_start = element.get("x_start", 0)
             y_start = element.get("y_start", 0)


### PR DESCRIPTION
Labels in plots are currently drawn with antialiasing. The reason was a missing `fontmode` specification. This should fix this.