### PR TITLE
fix(ble_atc): fix garbled display on ATC BLE tags

### DIFF
--- a/custom_components/open_epaper_link/config_flow.py
+++ b/custom_components/open_epaper_link/config_flow.py
@@ -49,7 +49,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     context between user interactions.
     """
 
-    VERSION = 2
+    VERSION = 3
 
     def __init__(self) -> None:
         """Initialize flow."""


### PR DESCRIPTION
This pull request introduces several updates to the OpenEPaperLink integration, focusing on migration improvements and schema updates for BLE device configuration entries. The most significant change is the addition of a migration function to update existing config entries to a new schema version, ensuring better compatibility and data consistency. Additionally, the config flow version is incremented to reflect these schema changes. Several new asynchronous helper functions are also introduced, improving modularity and maintainability.

**Migration and Schema Updates:**

* Added `async_migrate_entry` function to migrate old config entries to schema version 3, including adding `device_type` and `protocol_type` fields to BLE entries and converting boolean `rotatebuffer` values to integers in device metadata.
* Updated config flow version from 2 to 3 in `config_flow.py` to align with the new schema migration logic.