### PR TITLE
drawcustom text improvements

### DIFF
--- a/custom_components/open_epaper_link/imagegen/text.py
+++ b/custom_components/open_epaper_link/imagegen/text.py
@@ -205,10 +205,13 @@ async def draw_multiline(ctx: DrawingContext, element: dict) -> None:
     stroke_fill = ctx.colors.resolve(element.get('stroke_fill', 'white'))
 
     x = ctx.coords.parse_x(element['x'])
-    if "y" not in element:
-        current_y = ctx.pos_y + element.get('y_padding', 10)
-    else:
+    # Support both 'y' (standard) and 'start_y' (legacy) for backward compatibility
+    if "y" in element:
         current_y = ctx.coords.parse_y(element['y'])
+    elif "start_y" in element:
+        current_y = ctx.coords.parse_y(element['start_y'])
+    else:
+        current_y = ctx.pos_y + element.get('y_padding', 10)
 
     # Split text using delimiter
     lines = element['value'].replace("\n", "").split(element["delimiter"])

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -288,6 +288,26 @@ Notes:
 - Works with Home Assistant templates
 - The `accent` color automatically adapts to the display type (red or yellow)
 
+#### Multiline Text with parse_colors
+
+When `parse_colors` is enabled, text elements support newline characters (`\n`) for creating multi-line colored text:
+
+```yaml
+- type: text
+  value: "Line 1\n[red]Red Line 2[/red]\n[yellow]Yellow Line 3[/yellow]"
+  x: "50%"
+  y: "50%"
+  font: "ppb.ttf"
+  size: 24
+  parse_colors: true
+  anchor: "mm"
+```
+Anchor Behavior with Multiline Colored Text:
+  - Anchors apply to the entire text block (all lines together)
+  - For example, anchor: "mm" centers the entire block at the specified coordinates
+  - Line spacing is controlled by the spacing parameter
+  - Each line respects the align parameter (left, center, right)
+
 ### Multiline Text
 Splits text into multiple lines based on a delimiter.
 
@@ -308,7 +328,7 @@ Splits text into multiple lines based on a delimiter.
 | `delimiter` | Character to split text        | Yes      | -                         | Single character                            |
 | `x`         | X position                     | Yes      | -                         | Pixels or percentage                        |
 | `offset_y`  | Vertical spacing between lines | Yes      | -                         | Pixels                                      |
-| `start_y`   | Starting Y position            | No       | Last position + y_padding | Pixels or percentage                        |
+| `y`         | Starting Y position            | No       | Last position + y_padding | Pixels or percentage                        |
 | `size`      | Font size                      | No       | `20`                      | Pixels                                      |
 | `font`      | Font file name                 | No       | `ppb.ttf`                 | Available fonts: `ppb.ttf`, `rbm.ttf`       |
 | `color`     | Text color                     | No       | `black`                   | `white`, `black`, `accent`, `red`, `yellow` |


### PR DESCRIPTION
This pull request enhances the handling of multi-line and colored text rendering in the image generation module, improves anchor and alignment behavior for multi-line colored text, and updates the documentation to reflect these new capabilities and parameter changes.

**Improvements to multi-line colored text rendering:**
- Added support for newline characters (`\n`) in text elements with `parse_colors` enabled, allowing for multi-line colored text blocks. The anchor now applies to the entire block, and line spacing and alignment are handled per line. [[1]](diffhunk://#diff-862a0088701dd003f508d25668f7a27bda65a7efd5795da3ea0fd376169d534aR90-R134) [[2]](diffhunk://#diff-862a0088701dd003f508d25668f7a27bda65a7efd5795da3ea0fd376169d534aR384-R465)
- Introduced new helper functions: `split_segments_by_newlines`, `calculate_multiline_positions`, and `calculate_anchor_offset_y` to manage splitting colored text by lines, calculating vertical positions, and applying anchor offsets for multi-line text.

**Consistency and parameter improvements:**
- Standardized the use of the `y` parameter (with fallback to `start_y` for legacy support) for vertical positioning in `draw_multiline`, and ensured consistent use of the `x` parameter throughout. [[1]](diffhunk://#diff-862a0088701dd003f508d25668f7a27bda65a7efd5795da3ea0fd376169d534aR207-R224) [[2]](diffhunk://#diff-862a0088701dd003f508d25668f7a27bda65a7efd5795da3ea0fd376169d534aL193-R253)
- Changed text drawing functions to use the `"lt"` (left-top) anchor for individual segments, improving alignment consistency. [[1]](diffhunk://#diff-862a0088701dd003f508d25668f7a27bda65a7efd5795da3ea0fd376169d534aL101-R146) [[2]](diffhunk://#diff-862a0088701dd003f508d25668f7a27bda65a7efd5795da3ea0fd376169d534aL180-R233)

**Documentation updates:**
- Updated documentation to describe the new multi-line colored text feature, anchor behavior, and line spacing for colored text blocks.
- Updated the documentation for multi-line text to clarify that the `y` parameter is now used for starting Y position, replacing `start_y`.