### PR TITLE
feat(upload): add refresh_type parameter to support partial refresh

### DIFF
--- a/custom_components/open_epaper_link/services.yaml
+++ b/custom_components/open_epaper_link/services.yaml
@@ -63,6 +63,33 @@ drawcustom:
           min: 0
           max: 86400
           unit_of_measurement: seconds
+    refresh_type:
+      name: Refresh type
+      description: >
+        E-paper display refresh mode.
+        
+        - Full: Best quality (~2s), full screen refresh.
+        
+        - Fast: Moderate quality (~1s), quick update.
+        
+        - Partial: Fastest (~0.3s), may show ghosting.
+        
+        - Partial2: Alternative partial mode.
+        
+        Note: ATC BLE tags do not support this parameter.
+      required: false
+      default: "0"
+      selector:
+        select:
+          options:
+            - label: "Full (best quality)"
+              value: "0"
+            - label: "Fast (moderate quality)"
+              value: "1"
+            - label: "Partial (fastest)"
+              value: "2"
+            - label: "Partial2 (alternative partial)"
+              value: "3"
     dry-run:
       name: Dry run
       description: Generate image but don't send to device


### PR DESCRIPTION
This pull request adds support for specifying the e-paper display refresh mode when uploading images, both via BLE and through the hub/AP. It introduces a new `refresh_type` parameter to the service, propagates it through the upload pipeline, and ensures it is correctly mapped and sent to the hardware. The changes also include user-facing documentation and UI improvements for the new option.

**Support for e-paper display refresh modes:**

* Added a `refresh_type` parameter to the `drawcustom` service in `services.yaml`, with selectable options for Full, Fast, Partial, and Partial2 refresh modes, including detailed descriptions for users.
* Introduced the `RefreshMode` enum in `image_upload.py` to represent the available display refresh modes.
* Updated the BLE direct write upload pipeline (`upload_to_ble_direct`, `upload_direct_write`, and related methods) to accept and handle the `refresh_type` parameter, ensuring it is sent to the device at the end of the upload. [[1]](diffhunk://#diff-7fcbad20e2f9dba6561eaf34ac2456077697b9e9b97933eed4c76bece73b3e0aL408-R414) [[2]](diffhunk://#diff-7fcbad20e2f9dba6561eaf34ac2456077697b9e9b97933eed4c76bece73b3e0aL421-R437) [[3]](diffhunk://#diff-7fcbad20e2f9dba6561eaf34ac2456077697b9e9b97933eed4c76bece73b3e0aL470-R477) [[4]](diffhunk://#diff-1d7e09f1312ef326e5d6e03ff1484701bcd2934ee8ea22ad16d9073b6cf1b88fL726-R736) [[5]](diffhunk://#diff-1d7e09f1312ef326e5d6e03ff1484701bcd2934ee8ea22ad16d9073b6cf1b88fR745) [[6]](diffhunk://#diff-1d7e09f1312ef326e5d6e03ff1484701bcd2934ee8ea22ad16d9073b6cf1b88fR754-R755) [[7]](diffhunk://#diff-1d7e09f1312ef326e5d6e03ff1484701bcd2934ee8ea22ad16d9073b6cf1b88fL772-R789) [[8]](diffhunk://#diff-1d7e09f1312ef326e5d6e03ff1484701bcd2934ee8ea22ad16d9073b6cf1b88fR506) [[9]](diffhunk://#diff-1d7e09f1312ef326e5d6e03ff1484701bcd2934ee8ea22ad16d9073b6cf1b88fL917-R931)

**Integration with hub/AP uploads:**

* Extended the hub upload function (`upload_to_hub`) to accept a `lut` parameter (mapped from `refresh_type`), and ensured it is included in the upload request and debug logs. [[1]](diffhunk://#diff-7fcbad20e2f9dba6561eaf34ac2456077697b9e9b97933eed4c76bece73b3e0aL216-R216) [[2]](diffhunk://#diff-7fcbad20e2f9dba6561eaf34ac2456077697b9e9b97933eed4c76bece73b3e0aL233-R242) [[3]](diffhunk://#diff-7fcbad20e2f9dba6561eaf34ac2456077697b9e9b97933eed4c76bece73b3e0aR258)
* In the service handler, mapped `refresh_type` to the appropriate AP LUT values and passed it through the upload queue for hub uploads. [[1]](diffhunk://#diff-8a3f1caf902ba2060e6c66357a4b6ed5def813985adbc190d853bffde50589e3R291-R292) [[2]](diffhunk://#diff-8a3f1caf902ba2060e6c66357a4b6ed5def813985adbc190d853bffde50589e3L318-R339)

These changes provide users with more control over display update speed and quality, and ensure the new option is consistently supported across both BLE and hub upload paths.