### PR TITLE
fix missing names on ble discovery

### DIFF
--- a/custom_components/open_epaper_link/config_flow.py
+++ b/custom_components/open_epaper_link/config_flow.py
@@ -227,6 +227,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }
         _LOGGER.debug("Discovered device info: %s", self._discovered_device)
 
+        # Set discovery context for proper display in UI
+        self.context["title_placeholders"] = {
+            "name": self._discovered_device["name"],
+        }
+
         return await self.async_step_bluetooth_confirm()
 
     async def async_step_bluetooth_confirm(


### PR DESCRIPTION
This pull request introduces a small but important improvement to the Bluetooth device discovery flow in `custom_components/open_epaper_link/config_flow.py`. The main change ensures that the discovered device's name is properly displayed in the UI during configuration.

* Bluetooth discovery flow improvement:
  * Sets the `title_placeholders` in the `context` with the discovered device's name to ensure correct display in the UI.