### PR TITLE
Allow drawing files from /media folder

### DIFF
--- a/custom_components/open_epaper_link/imagegen/media.py
+++ b/custom_components/open_epaper_link/imagegen/media.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 import base64
 import io
 import logging
-import os
 import urllib
+from pathlib import Path
 
-import requests
 import qrcode
-from PIL import Image
-from resizeimage import resizeimage
+import requests
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.network import get_url
+from PIL import Image
+from resizeimage import resizeimage
 
 from ..const import DOMAIN
 from .registry import element_handler
-from .types import ElementType, DrawingContext
+from .types import DrawingContext, ElementType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ async def draw_qrcode(ctx: DrawingContext, element: dict) -> None:
             translation_domain=DOMAIN,
             translation_key="qr_generation_failed",
             translation_placeholders={ "error": str(e)}
-        )
+        ) from e
 
 
 @element_handler(ElementType.DLIMG, requires=["x", "y", "url", "xsize", "ysize"])
@@ -154,13 +154,25 @@ async def draw_downloaded_image(ctx: DrawingContext, element: dict) -> None:
                     translation_domain=DOMAIN,
                     translation_key="image_data_uri_invalid",
                     translation_placeholders={ "error": str(e)}
-                )
+                ) from e
 
         else:
             # Handle local file
             if not element['url'].startswith('/'):
-                media_path = ctx.hass.config.path('media')
-                full_path = os.path.join(media_path, element['url'])
+                if not ctx.hass.config.is_allowed_path(element['url']):
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="image_local_path_not_allowed",
+                        translation_placeholders={ "path": element['url']}
+                    )
+                full_path = Path(element['url'])
+                if not full_path.exists():
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="image_local_path_not_found",
+                        translation_placeholders={ "path": str(full_path)}
+                    )
+                
             else:
                 full_path = element['url']
             source_img = await ctx.hass.async_add_executor_job(Image.open, full_path)
@@ -174,7 +186,7 @@ async def draw_downloaded_image(ctx: DrawingContext, element: dict) -> None:
             if resize_method in ['crop', 'cover', 'contain']:
                 source_img = resizeimage.resize(resize_method, source_img, target_size)
             elif resize_method != 'stretch':
-                _LOGGER.warning(f"Warning: resize_method is set to unsupported method '{resize_method}', this will result in simple stretch resizing")
+                _LOGGER.warning("Warning: resize_method is set to unsupported method %s, this will result in simple stretch resizing", resize_method)
 
             if source_img.size != target_size:
                 source_img = source_img.resize(target_size)
@@ -197,4 +209,4 @@ async def draw_downloaded_image(ctx: DrawingContext, element: dict) -> None:
             translation_domain=DOMAIN,
             translation_key="image_process_failed",
             translation_placeholders={ "error": str(e)}
-        )
+        ) from e

--- a/custom_components/open_epaper_link/translations/de.json
+++ b/custom_components/open_epaper_link/translations/de.json
@@ -399,6 +399,8 @@
         "ble_no_metadata": "Keine Metadaten für BLE-Gerät {entity_id} gefunden.",
         "ble_upload_failed": "BLE-Bildupload für {entity_id} fehlgeschlagen.",
         "ble_direct_write_not_supported": "Direktes Schreiben wird nur für OEPL-Geräte unterstützt, aber {entity_id} scheint ein ATC-Gerät zu sein.",
+        "image_local_path_not_allowed": { "message": "Konnte {path} nicht lesen, kein Zugriff auf Pfad; `allowlist_external_dirs` muss möglicherweise in `configuration.yaml` angepasst werden" },
+        "image_local_path_not_found": { "message": "Lokaler Pfad {path} nicht gefunden." },
         "image_upload_status": "Bild-Upload für {entity_id} fehlgeschlagen mit Statuscode: {status_code}.",
         "image_upload_timeout": "Bild-Upload für {entity_id} nach {attempts} Versuchen wegen Zeitüberschreitung fehlgeschlagen.",
         "image_upload_network": "Netzwerkfehler beim Bild-Upload für {entity_id}: {error}.",

--- a/custom_components/open_epaper_link/translations/en.json
+++ b/custom_components/open_epaper_link/translations/en.json
@@ -297,6 +297,8 @@
     "ble_upload_failed": { "message": "BLE image upload failed for {entity_id}." },
     "ble_direct_write_failed": { "message": "BLE direct write upload failed for {entity_id}." },
     "ble_direct_write_not_supported": { "message": "Direct write is only supported for OEPL devices, but {entity_id} appears to be an ATC device." },
+    "image_local_path_not_allowed": { "message": "Cannot read {path}, no access to path; `allowlist_external_dirs` may need to be adjusted in `configuration.yaml`" },
+    "image_local_path_not_found": { "message": "Local image path {path} not found." },
     "image_upload_status": { "message": "Image upload failed for {entity_id} with status code: {status_code}." },
     "image_upload_timeout": { "message": "Image upload timed out for {entity_id} after {attempts} attempts." },
     "image_upload_network": { "message": "Network error uploading image for {entity_id}: {error}." },


### PR DESCRIPTION
In the currently implementation Home Assitant will always add a `/config` to the beginning of local paths, which effectively blocks access to the `/media` folder - the folder where uploaded media is usually stored.

This PR changes the base and checks if HA has access to the specified file & folder. Since the base path chages this can be a breaking change for some users.

Additionally, make sure exceptions are properly re-raised.