### PR TITLE
Fix for ""Detected that custom integration 'open_epaper_link' sets an…

### DIFF
--- a/custom_components/open_epaper_link/sensor.py
+++ b/custom_components/open_epaper_link/sensor.py
@@ -483,7 +483,6 @@ class OpenEPaperLinkTagSensor(OpenEPaperLinkTagEntity, SensorEntity):
         self.entity_description = description
         self._attr_translation_key = description.key
         self._attr_unique_id = f"{tag_mac}_{description.key}"
-        self.entity_id = f"{DOMAIN}.{tag_mac.lower()}_{description.key}"
         self._attr_entity_registry_enabled_default = description.entity_registry_enabled_default
 
     @property


### PR DESCRIPTION
This fixes issue 341 - … entity ID with wrong domain: 'open_epaper_link.00000a2818c93d1b_temperature'. Expected domain is 'sensor'. This will stop working in Home Assistant 2027.5.0, please create a bug report at https://github.com/OpenEPaperLink/Home_Assistant_Integration/issues"

As of the recent 2026 updates, Home Assistant now requires that the domain matches the functional category of the entity.
    Old way: integration_name.device_name_feature
    New way: sensor.device_name_feature

